### PR TITLE
Improve merge failure handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ vid-timestamps /path/to/video_folder
 vid-merge /path/to/video_folder
 ```
 🔹 Confirms timestamps before merging videos.
+🔹 If `ffmpeg` fails during the merge, an error message is displayed instead of a success notice.
 
 🔹 The default output file name is **the folder name**, but you can specify an output file with `-o`:
 ```bash

--- a/vidtoolbox/merge_videos.py
+++ b/vidtoolbox/merge_videos.py
@@ -135,7 +135,11 @@ def merge_videos(video_directory, output_file=None, keep_filelist=False, reencod
             "-i", file_list_path, "-c", "copy", output_file
         ]
     
-    subprocess.run(cmd)
+    result = subprocess.run(cmd)
+    if result.returncode != 0:
+        print(f"❌ Video merge failed with return code {result.returncode}")
+        return
+
     print(f"✅ Video merge completed! Output file: {output_file}")
 
     # **Automatically delete file_list.txt**


### PR DESCRIPTION
## Summary
- check ffmpeg exit status before declaring success
- document ffmpeg failure message in README

## Testing
- `python -m py_compile vidtoolbox/generate_timestamps.py vidtoolbox/merge_videos.py`

------
https://chatgpt.com/codex/tasks/task_e_68822eba62bc8333b3381dfaf9c3d53d